### PR TITLE
Fix error on "type name is not allowed"

### DIFF
--- a/gpu/utils/Tensor.cuh
+++ b/gpu/utils/Tensor.cuh
@@ -359,7 +359,7 @@ bool canUseIndexType() {
 
 template <typename IndexType, typename T, typename... U>
 bool canUseIndexType(const T& arg, const U&... args) {
-  return arg.canUseIndexType<IndexType>() &&
+  return arg.canUseIndexType() &&
     canUseIndexType(args...);
 }
 


### PR DESCRIPTION
Fixes `error: type name is not allowed` in CUDA 10.1, Ubuntu 18.04 referenced from an external project ([tsne-cuda](https://github.com/CannyLab/tsne-cuda)).

This change fixes the following error in a build procedure https://github.com/CannyLab/tsne-cuda/wiki/Installation#building-from-source

```
$ make
[  9%] Built target faiss
[ 11%] Built target glog
[ 12%] Built target gtest
[ 13%] Building NVCC (Device) object CMakeFiles/tsnecuda.dir/third_party/faiss/gpu/tsnecuda_generated_GpuIndexFlat.cu.o
/opt/tsne-cuda/third_party/faiss/gpu/impl/../utils/Tensor.cuh(362): error: type name is not allowed

/opt/tsne-cuda/third_party/faiss/gpu/impl/../utils/Tensor.cuh(362): error: expected an expression

2 errors detected in the compilation of "/tmp/tmpxft_00003467_00000000-4_GpuIndexFlat.cpp4.ii".
CMake Error at tsnecuda_generated_GpuIndexFlat.cu.o.cmake:275 (message):
  Error generating file
  /opt/tsne-cuda/build/CMakeFiles/tsnecuda.dir/third_party/faiss/gpu/./tsnecuda_generated_GpuIndexFlat.cu.o
```

According to the contributing guidelines, I confirmed that `make test` passes after this change in my environment below:

```
$ /usr/local/cuda-10.1/bin/nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2019 NVIDIA Corporation
Built on Fri_Feb__8_19:08:17_PST_2019
Cuda compilation tools, release 10.1, V10.1.105
```
```
$ uname -a
Linux ubuntu3 4.15.0-47-generic #50-Ubuntu SMP Wed Mar 13 10:44:52 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
```
```
$ cmake --version
cmake version 3.14.3

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```
```
$ g++ --version
g++ (Ubuntu 7.3.0-27ubuntu1~18.04) 7.3.0
```